### PR TITLE
Add set_engine() into Signals class

### DIFF
--- a/src/hwc/common/_base.py
+++ b/src/hwc/common/_base.py
@@ -119,6 +119,11 @@ class Signals(metaclass=SingletonMeta):
         """Set all updated signal states using given engine."""
         self._engine.write_states()
 
+    def set_engine(self, engine) -> None:
+        """Set engine instance."""
+        self._engine = engine
+        self._engine.associate_signal_members(self.__signal_members__)
+
     def __iter__(self):
         self._next_index = 0
         return self

--- a/src/hwc/common/_base.py
+++ b/src/hwc/common/_base.py
@@ -119,7 +119,7 @@ class Signals(metaclass=SingletonMeta):
         """Set all updated signal states using given engine."""
         self._engine.write_states()
 
-    def set_engine(self, engine) -> None:
+    def set_engine(self, engine: SignalsEngine) -> None:
         """Set engine instance.
         :param engine: engine instance to be set"""
         self._engine = engine

--- a/src/hwc/common/_base.py
+++ b/src/hwc/common/_base.py
@@ -120,7 +120,8 @@ class Signals(metaclass=SingletonMeta):
         self._engine.write_states()
 
     def set_engine(self, engine) -> None:
-        """Set engine instance."""
+        """Set engine instance.
+        :param engine: engine instance to be set"""
         self._engine = engine
         self._engine.associate_signal_members(self.__signal_members__)
 


### PR DESCRIPTION
Adds set_engine() method to be able to dynamically swap the engine for objects of classes inherited from Signals (for example when IP address or port is modified)