### PR TITLE
Fix pymodbus version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 0.2.1
+[PATCH] Fix required version of pymodbus to 3.9.2 (due to breaking changes in 3.10)
+
 ### 0.2.0
 
 [MINOR] Signals and SignalsEngine are no longer "Singleton".

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pymodbus~=3.9
+pymodbus==3.9.2
 pyserial
 retry


### PR DESCRIPTION
Fix required version of pymodbus to 3.9.2 (due to breaking changes in 3.10)